### PR TITLE
warnings: tell the compiler that the variable is within bounds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -378,7 +378,6 @@ AC_ARG_ENABLE(g,
                    eliminate access warnings from programs like valgrind
         memarena - Check for overwrite errors in memory allocation arena
         mutex    - Enable error checking on pthread mutexes
-        mutexnesting - Check for non-nesting of mutexes
         most     - Most of the above options, excluding some with severe
                    performance impacts.  Recommended for typical development.
         yes      - synonym for "most" (*not* "all")
@@ -1645,15 +1644,11 @@ for option in $enable_g ; do
 	mutex)
 	perform_dbgmutex=yes
 	;;
-	mutexnesting)
-	perform_mutexnesting=yes
-	;;
         most|yes)
         perform_memtracing=yes
         enable_append_g=yes
         perform_meminit=yes
         perform_dbgmutex=yes
-        perform_mutexnesting=yes
         perform_handlealloc=yes
         perform_handle=yes
         ;;
@@ -1663,7 +1658,6 @@ for option in $enable_g ; do
 	enable_append_g=yes
 	perform_meminit=yes
 	perform_dbgmutex=yes
-	perform_mutexnesting=yes
 	perform_handlealloc=yes
         perform_handle=yes
 	;;

--- a/maint/checkbuilds.in
+++ b/maint/checkbuilds.in
@@ -56,7 +56,7 @@ $hasDemon   = 0;
 		  'error-messages;all;generic;class;none',
 		  'timer-type;linux86_cycle;gethrtime;clock_gettime;gettimeofday',
 		  'timing;none;all;runtime;log;log_detailed',
-		  'g;none;all;handle;dbg;log;meminit;handlealloc;instr;mem;mutex;mutexnesting;memarena',
+		  'g;none;all;handle;dbg;log;meminit;handlealloc;instr;mem;mutex;memarena',
 		  'fast;nochkmsg;notiming;ndebug;all',
 		  'f77',
 		  'fc',

--- a/src/include/mpiimpl.h
+++ b/src/include/mpiimpl.h
@@ -218,7 +218,7 @@ typedef struct MPIR_Topology MPIR_Topology;
 /********************* PART 5: DEVICE DEPENDENT HEADERS **********************/
 /*****************************************************************************/
 
-#include "mpir_thread.h"
+#include "mpir_thread.h"        /* come first as mutexes are often depended on, e.g. request */
 #include "mpir_attr.h"
 #include "mpir_group.h"
 #include "mpir_comm.h"

--- a/src/include/mpir_handlemem.h
+++ b/src/include/mpir_handlemem.h
@@ -333,10 +333,16 @@ Input Parameters:
   +*/
 static inline void MPIR_Handle_obj_free(MPIR_Object_alloc_t * objmem, void *object)
 {
-    MPIR_Handle_common *obj = (MPIR_Handle_common *) object;
-
     MPID_THREAD_CS_ENTER(POBJ, MPIR_THREAD_POBJ_HANDLE_MUTEX);
     MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_VCI_HANDLE_MUTEX);
+    MPIR_Handle_obj_free_unsafe(objmem, object);
+    MPID_THREAD_CS_EXIT(POBJ, MPIR_THREAD_POBJ_HANDLE_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI, MPIR_THREAD_VCI_HANDLE_MUTEX);
+}
+
+static inline void MPIR_Handle_obj_free_unsafe(MPIR_Object_alloc_t * objmem, void *object)
+{
+    MPIR_Handle_common *obj = (MPIR_Handle_common *) object;
 
     MPL_DBG_MSG_FMT(MPIR_DBG_HANDLE, TYPICAL, (MPL_DBG_FDEST,
                                                "Freeing object ptr %p (0x%08x kind=%s) refcount=%d",
@@ -380,8 +386,6 @@ static inline void MPIR_Handle_obj_free(MPIR_Object_alloc_t * objmem, void *obje
 
     obj->next = objmem->avail;
     objmem->avail = obj;
-    MPID_THREAD_CS_EXIT(POBJ, MPIR_THREAD_POBJ_HANDLE_MUTEX);
-    MPID_THREAD_CS_EXIT(VCI, MPIR_THREAD_VCI_HANDLE_MUTEX);
 }
 
 /*

--- a/src/include/mpir_handlemem.h
+++ b/src/include/mpir_handlemem.h
@@ -30,7 +30,7 @@ int MPIR_check_handles_on_finalize(void *objmem_ptr);
    define MPID_<OBJ>_PREALLOC 256
    MPIR_Object_alloc_t MPID_<obj>_mem = { 0, 0, 0, 0, MPID_<obj>,
                                           sizeof(MPID_<obj>), MPID_<obj>_direct,
-                                          MPID_<OBJ>_PREALLOC, };
+                                          MPID_<OBJ>_PREALLOC, NULL};
 
    // Preallocated objects
    MPID_<obj> MPID_<obj>_direct[MPID_<OBJ>_PREALLOC];

--- a/src/include/mpir_objects.h
+++ b/src/include/mpir_objects.h
@@ -421,6 +421,12 @@ typedef struct MPIR_Object_alloc_t {
     void *direct;               /* Pointer to direct block, used
                                  * for allocation */
     int direct_size;            /* Size of direct block */
+    void *lock;                 /* lower-layer may register a lock to use. This is
+                                 * mostly for multipool requests. For other objects
+                                 * or not per-vci thread granularity, this lock
+                                 * pointer is ignored. Ref. mpir_request.h.
+                                 * NOTE: it is `void *` because mutex type not defined yet.
+                                 */
 } MPIR_Object_alloc_t;
 static inline void *MPIR_Handle_obj_alloc(MPIR_Object_alloc_t *);
 static inline void *MPIR_Handle_obj_alloc_unsafe(MPIR_Object_alloc_t *,

--- a/src/include/mpir_objects.h
+++ b/src/include/mpir_objects.h
@@ -423,7 +423,8 @@ typedef struct MPIR_Object_alloc_t {
     int direct_size;            /* Size of direct block */
 } MPIR_Object_alloc_t;
 static inline void *MPIR_Handle_obj_alloc(MPIR_Object_alloc_t *);
-static inline void *MPIR_Handle_obj_alloc_unsafe(MPIR_Object_alloc_t *);
+static inline void *MPIR_Handle_obj_alloc_unsafe(MPIR_Object_alloc_t *,
+                                                 int max_blocks, int max_indices);
 static inline void MPIR_Handle_obj_free(MPIR_Object_alloc_t *, void *);
 static inline void *MPIR_Handle_get_ptr_indirect(int, MPIR_Object_alloc_t *);
 

--- a/src/include/mpir_objects.h
+++ b/src/include/mpir_objects.h
@@ -426,6 +426,7 @@ static inline void *MPIR_Handle_obj_alloc(MPIR_Object_alloc_t *);
 static inline void *MPIR_Handle_obj_alloc_unsafe(MPIR_Object_alloc_t *,
                                                  int max_blocks, int max_indices);
 static inline void MPIR_Handle_obj_free(MPIR_Object_alloc_t *, void *);
+static inline void MPIR_Handle_obj_free_unsafe(MPIR_Object_alloc_t *, void *);
 static inline void *MPIR_Handle_get_ptr_indirect(int, MPIR_Object_alloc_t *);
 
 

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -204,7 +204,8 @@ struct MPIR_Request {
  * are extended here for request objects. It is separate from the other objects, and the
  * bit patterns for POOL and BLOCK sizes can be adjusted if necessary.
  *
- * NOTE: MPIR_Request_create/free are patched to work with pools.
+ * MPIR_Request_create_from_pool is used to create request objects from a specific pool.
+ * MPIR_Request_create is a wrapper to create request from pool 0.
  */
 /* Handle Bits - 2+4+6+8+12 - Type, Kind, Pool_idx, Block_idx, Object_idx */
 #define REQUEST_POOL_MASK    0x03f00000
@@ -278,7 +279,7 @@ static inline int MPIR_Request_is_active(MPIR_Request * req_ptr)
                                          | MPIR_REQUESTS_PROPERTY__NO_GREQUESTS   \
                                          | MPIR_REQUESTS_PROPERTY__SEND_RECV_ONLY)
 
-static inline MPIR_Request *MPIR_Request_create(MPIR_Request_kind_t kind, int pool)
+static inline MPIR_Request *MPIR_Request_create_from_pool(MPIR_Request_kind_t kind, int pool)
 {
     MPIR_Request *req;
 
@@ -346,6 +347,11 @@ static inline MPIR_Request *MPIR_Request_create(MPIR_Request_kind_t kind, int po
     return req;
 }
 
+static inline MPIR_Request *MPIR_Request_create(MPIR_Request_kind_t kind)
+{
+    return MPIR_Request_create_from_pool(kind, 0);
+}
+
 #define MPIR_Request_add_ref(req_p_) \
     do { MPIR_Object_add_ref(req_p_); } while (0)
 
@@ -357,7 +363,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIR_Request_create_complete(MPIR_Request
     MPIR_Request *req;
 
 #ifdef HAVE_DEBUGGER_SUPPORT
-    req = MPIR_Request_create(kind, 0);
+    req = MPIR_Request_create(kind);
     MPIR_cc_set(&req->cc, 0);
 #else
     req = MPIR_Process.lw_req;

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -301,6 +301,9 @@ static inline MPIR_Request *MPIR_Request_create_from_pool(MPIR_Request_kind_t ki
 {
     MPIR_Request *req;
 
+#ifdef MPICH_DEBUG_MUTEX
+    MPID_THREAD_ASSERT_IN_CS(VCI, (*(MPID_Thread_mutex_t *) MPIR_Request_mem[pool].lock));
+#endif
     req = MPIR_Handle_obj_alloc_unsafe(&MPIR_Request_mem[pool],
                                        REQUEST_NUM_BLOCKS, REQUEST_NUM_INDICES);
     if (req != NULL) {
@@ -446,6 +449,9 @@ static inline void MPIR_Request_free_with_safety(MPIR_Request * req, int need_sa
             MPID_THREAD_CS_EXIT(POBJ, MPIR_THREAD_POBJ_HANDLE_MUTEX);
             MPID_THREAD_CS_EXIT(VCI, (*(MPID_Thread_mutex_t *) MPIR_Request_mem[pool].lock));
         } else {
+#ifdef MPICH_DEBUG_MUTEX
+            MPID_THREAD_ASSERT_IN_CS(VCI, (*(MPID_Thread_mutex_t *) MPIR_Request_mem[pool].lock));
+#endif
             MPIR_Handle_obj_free_unsafe(&MPIR_Request_mem[pool], req);
         }
     }

--- a/src/mpi/attr/attrutil.c
+++ b/src/mpi/attr/attrutil.c
@@ -23,6 +23,7 @@ MPIR_Object_alloc_t MPII_Keyval_mem = { 0, 0, 0, 0, MPIR_KEYVAL,
     sizeof(MPII_Keyval),
     MPII_Keyval_direct,
     MPID_KEYVAL_PREALLOC,
+    NULL
 };
 
 #ifndef MPIR_ATTR_PREALLOC
@@ -36,6 +37,7 @@ MPIR_Object_alloc_t MPID_Attr_mem = { 0, 0, 0, 0, MPIR_ATTR,
     sizeof(MPIR_Attribute),
     MPID_Attr_direct,
     MPIR_ATTR_PREALLOC,
+    NULL
 };
 
 /* Provides a way to trap all attribute allocations when debugging leaks. */

--- a/src/mpi/coll/op/op_create.c
+++ b/src/mpi/coll/op/op_create.c
@@ -36,6 +36,7 @@ MPIR_Object_alloc_t MPIR_Op_mem = { 0, 0, 0, 0, MPIR_OP,
     sizeof(MPIR_Op),
     MPIR_Op_direct,
     MPIR_OP_PREALLOC,
+    NULL
 };
 
 #ifdef HAVE_CXX_BINDING

--- a/src/mpi/coll/transports/gentran/tsp_gentran.c
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.c
@@ -404,7 +404,7 @@ int MPII_Genutil_sched_start(MPII_Genutil_sched_t * sched, MPIR_Comm * comm, MPI
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPII_GENUTIL_SCHED_START);
 
     /* Create a request */
-    reqp = MPIR_Request_create(MPIR_REQUEST_KIND__COLL, 0);
+    reqp = MPIR_Request_create(MPIR_REQUEST_KIND__COLL);
     if (!reqp)
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
     *req = reqp;

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -29,7 +29,8 @@ MPIR_Object_alloc_t MPIR_Comm_mem = {
     MPIR_COMM,
     sizeof(MPIR_Comm),
     MPIR_Comm_direct,
-    MPID_COMM_PREALLOC
+    MPID_COMM_PREALLOC,
+    NULL
 };
 
 /* Communicator creation functions */

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -190,10 +190,7 @@ int MPIR_Datatype_init_predefined(void)
         /* XXX DJG it does work, but only because MPI_LONG_DOUBLE_INT is the
          * only one that is ever optional and it comes last */
 
-        /* we use the _unsafe version because we are still in MPI_Init, before
-         * multiple threads are permitted and possibly before support for
-         * critical sections is entirely setup */
-        dptr = (MPIR_Datatype *) MPIR_Handle_obj_alloc_unsafe(&MPIR_Datatype_mem);
+        dptr = (MPIR_Datatype *) MPIR_Handle_obj_alloc(&MPIR_Datatype_mem);
 
         MPIR_Assert(dptr);
         MPIR_Assert(dptr->handle == mpi_pairtypes[i].dtype);

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -16,7 +16,8 @@ MPIR_Datatype MPIR_Datatype_direct[MPIR_DATATYPE_PREALLOC];
 
 MPIR_Object_alloc_t MPIR_Datatype_mem = { 0, 0, 0, 0, MPIR_DATATYPE,
     sizeof(MPIR_Datatype), MPIR_Datatype_direct,
-    MPIR_DATATYPE_PREALLOC
+    MPIR_DATATYPE_PREALLOC,
+    NULL
 };
 
 static int pairtypes_finalize_cb(void *dummy);

--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -149,6 +149,7 @@ MPIR_Object_alloc_t MPIR_Errhandler_mem = { 0, 0, 0, 0, MPIR_ERRHANDLER,
     sizeof(MPIR_Errhandler),
     MPIR_Errhandler_direct,
     MPIR_ERRHANDLER_PREALLOC,
+    NULL
 };
 
 void MPIR_Errhandler_free(MPIR_Errhandler * errhan_ptr)

--- a/src/mpi/group/grouputil.c
+++ b/src/mpi/group/grouputil.c
@@ -16,7 +16,8 @@ MPIR_Group MPIR_Group_direct[MPID_GROUP_PREALLOC];
 
 MPIR_Object_alloc_t MPIR_Group_mem = { 0, 0, 0, 0, MPIR_GROUP,
     sizeof(MPIR_Group), MPIR_Group_direct,
-    MPID_GROUP_PREALLOC
+    MPID_GROUP_PREALLOC,
+    NULL
 };
 
 MPIR_Group *const MPIR_Group_empty = &MPIR_Group_builtin[0];

--- a/src/mpi/info/infoutil.c
+++ b/src/mpi/info/infoutil.c
@@ -20,6 +20,7 @@ MPIR_Info MPIR_Info_direct[MPIR_INFO_PREALLOC];
 MPIR_Object_alloc_t MPIR_Info_mem = { 0, 0, 0, 0, MPIR_INFO,
     sizeof(MPIR_Info), MPIR_Info_direct,
     MPIR_INFO_PREALLOC,
+    NULL
 };
 
 /* Free an info structure.  In the multithreaded case, this routine

--- a/src/mpi/init/local_proc_attrs.c
+++ b/src/mpi/init/local_proc_attrs.c
@@ -129,7 +129,7 @@ int MPII_init_local_proc_attrs(int *p_thread_required)
 
     /* Create complete request to return in the event of immediately complete
      * operations. Use a SEND request to cover all possible use-cases. */
-    MPIR_Process.lw_req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
+    MPIR_Process.lw_req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
     MPIR_ERR_CHKANDSTMT(MPIR_Process.lw_req == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
                         "**nomemreq");
     MPIR_cc_set(&MPIR_Process.lw_req->cc, 0);

--- a/src/mpi/request/greq_start.c
+++ b/src/mpi/request/greq_start.c
@@ -39,6 +39,7 @@ MPIR_Object_alloc_t MPIR_Grequest_class_mem = { 0, 0, 0, 0, MPIR_GREQ_CLASS,
     sizeof(MPIR_Grequest_class),
     MPIR_Grequest_class_direct,
     MPIR_GREQ_CLASS_PREALLOC,
+    NULL
 };
 
 /* We jump through some minor hoops to manage the list of classes ourselves and

--- a/src/mpi/request/greq_start.c
+++ b/src/mpi/request/greq_start.c
@@ -80,7 +80,7 @@ int MPIR_Grequest_start(MPI_Grequest_query_function * query_fn,
 
     /* MT FIXME this routine is not thread-safe in the non-global case */
 
-    *request_ptr = MPIR_Request_create(MPIR_REQUEST_KIND__GREQUEST, 0);
+    *request_ptr = MPIR_Request_create(MPIR_REQUEST_KIND__GREQUEST);
     MPIR_ERR_CHKANDJUMP1(*request_ptr == NULL, mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
                          "generalized request");
 

--- a/src/mpi/rma/winutil.c
+++ b/src/mpi/rma/winutil.c
@@ -16,5 +16,6 @@ MPIR_Win MPIR_Win_direct[MPIR_WIN_PREALLOC];
 
 MPIR_Object_alloc_t MPIR_Win_mem = { 0, 0, 0, 0, MPIR_WIN,
     sizeof(MPIR_Win), MPIR_Win_direct,
-    MPIR_WIN_PREALLOC
+    MPIR_WIN_PREALLOC,
+    NULL
 };

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_impl.h
@@ -227,7 +227,7 @@ static inline int MPID_nem_ofi_create_req(MPIR_Request ** request, int refcnt)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req;
-    req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+    req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
     MPIR_Assert(req);
     MPIR_Object_set_ref(req, refcnt);
     MPID_nem_ofi_init_req(req);

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_send.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_send.c
@@ -355,7 +355,7 @@ int MPID_nem_tcp_iStartContigMsg(MPIDI_VC_t * vc, void *hdr, intptr_t hdr_sz, vo
     MPL_DBG_MSG(MPIDI_CH3_DBG_CHANNEL, VERBOSE, "enqueuing");
 
     /* create a request */
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
     MPIR_Assert(sreq != NULL);
     MPIR_Object_set_ref(sreq, 2);
 
@@ -438,7 +438,7 @@ int MPID_nem_tcp_iStartContigMsg_paused(MPIDI_VC_t * vc, void *hdr, intptr_t hdr
     MPL_DBG_MSG(MPIDI_CH3_DBG_CHANNEL, VERBOSE, "enqueuing");
 
     /* create a request */
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
     MPIR_Assert(sreq != NULL);
     MPIR_Object_set_ref(sreq, 2);
 

--- a/src/mpid/ch3/channels/nemesis/src/ch3_istartmsg.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_istartmsg.c
@@ -84,7 +84,7 @@ int MPIDI_CH3_iStartMsg (MPIDI_VC_t *vc, void *hdr, intptr_t hdr_sz, MPIR_Reques
 	MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER, TERSE, "enqueuing");
 
 	/* create a request */
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
 	MPIR_Assert (sreq != NULL);
 	MPIR_Object_set_ref (sreq, 2);
 

--- a/src/mpid/ch3/channels/nemesis/src/ch3_istartmsgv.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_istartmsgv.c
@@ -111,7 +111,7 @@ int MPIDI_CH3_iStartMsgv (MPIDI_VC_t *vc, struct iovec *iov, int n_iov, MPIR_Req
 	{
             /* Create a new request and save remaining portions of the
 	     * iov in it. */
-            sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+            sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
 	    MPIR_Assert(sreq != NULL);
 	    MPIR_Object_set_ref(sreq, 2);
 	    sreq->kind = MPIR_REQUEST_KIND__SEND;
@@ -142,7 +142,7 @@ int MPIDI_CH3_iStartMsgv (MPIDI_VC_t *vc, struct iovec *iov, int n_iov, MPIR_Req
 	
 	MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER, TERSE, "request enqueued");
 	/* create a request */
-	sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+	sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
 	MPIR_Assert(sreq != NULL);
 	MPIR_Object_set_ref(sreq, 2);
 	sreq->kind = MPIR_REQUEST_KIND__SEND;

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_mpich.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_mpich.c
@@ -87,7 +87,7 @@ int MPID_nem_send_iov(MPIDI_VC_t *vc, MPIR_Request **sreq_ptr, struct iovec *iov
     if (*sreq_ptr == NULL)
     {
 	/* create a request */
-	sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+	sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
 	MPIR_Assert(sreq != NULL);
 	MPIR_Object_set_ref(sreq, 2);
 	sreq->kind = MPIR_REQUEST_KIND__SEND;

--- a/src/mpid/ch3/channels/sock/src/ch3_istartmsg.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_istartmsg.c
@@ -12,7 +12,7 @@ static MPIR_Request *create_request(void *hdr, intptr_t hdr_sz, size_t nb)
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_CREATE_REQUEST);
 
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
     /* --BEGIN ERROR HANDLING-- */
     if (sreq == NULL)
         return NULL;
@@ -110,7 +110,7 @@ int MPIDI_CH3_iStartMsg(MPIDI_VC_t * vc, void *hdr, intptr_t hdr_sz, MPIR_Reques
             else {
                 MPL_DBG_MSG_D(MPIDI_CH3_DBG_CHANNEL, TYPICAL,
                               "ERROR - MPIDI_CH3I_Sock_write failed, rc=%d", rc);
-                sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+                sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
                 if (!sreq) {
                     MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
                 }
@@ -167,7 +167,7 @@ int MPIDI_CH3_iStartMsg(MPIDI_VC_t * vc, void *hdr, intptr_t hdr_sz, MPIR_Reques
     else {
         /* Connection failed, so allocate a request and return an error. */
         MPL_DBG_VCUSE(vc, "ERROR - connection failed");
-        sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+        sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
         if (!sreq) {
             MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
         }

--- a/src/mpid/ch3/channels/sock/src/ch3_istartmsgv.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_istartmsgv.c
@@ -13,7 +13,7 @@ static MPIR_Request *create_request(struct iovec * iov, int iov_count, int iov_o
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_CREATE_REQUEST);
 
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
     /* --BEGIN ERROR HANDLING-- */
     if (sreq == NULL)
         return NULL;
@@ -138,7 +138,7 @@ int MPIDI_CH3_iStartMsgv(MPIDI_VC_t * vc, struct iovec * iov, int n_iov, MPIR_Re
             else {
                 MPL_DBG_MSG_D(MPIDI_CH3_DBG_CHANNEL, TYPICAL,
                               "ERROR - MPIDI_CH3I_Sock_writev failed, rc=%d", rc);
-                sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
+                sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
                 if (sreq == NULL) {
                     MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
                 }
@@ -194,7 +194,7 @@ int MPIDI_CH3_iStartMsgv(MPIDI_VC_t * vc, struct iovec * iov, int n_iov, MPIR_Re
     else {
         /* Connection failed, so allocate a request and return an error. */
         MPL_DBG_VCUSE(vc, "ERROR - connection failed");
-        sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
+        sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
         if (sreq == NULL) {
             MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
         }

--- a/src/mpid/ch3/include/mpid_rma_issue.h
+++ b/src/mpid/ch3/include/mpid_rma_issue.h
@@ -222,7 +222,7 @@ static int issue_from_origin_buffer(MPIDI_RMA_Op_t * rma_op, MPIDI_VC_t * vc,
      * always need a request to be passed in. */
 
     /* create a new request */
-    req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
+    req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
     MPIR_ERR_CHKANDJUMP(req == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
 
     MPIR_Object_set_ref(req, 2);
@@ -564,7 +564,7 @@ static int issue_get_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
         /* Create a request for the GACC response.  Store the response buf, count, and
          * datatype in it, and pass the request's handle in the GACC packet. When the
          * response comes from the target, it will contain the request handle. */
-        resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+        resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
         MPIR_ERR_CHKANDJUMP(resp_req == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
 
         MPIR_Object_set_ref(resp_req, 2);
@@ -659,7 +659,7 @@ static int issue_get_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
         /* Create a request for the GACC response.  Store the response buf, count, and
          * datatype in it, and pass the request's handle in the GACC packet. When the
          * response comes from the target, it will contain the request handle. */
-        resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+        resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
         MPIR_ERR_CHKANDJUMP(resp_req == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
 
         MPIR_Object_set_ref(resp_req, 2);
@@ -785,7 +785,7 @@ static int issue_get_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
      * and pass a handle to it in the get packet. When the get
      * response comes from the target, it will contain the request
      * handle. */
-    curr_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+    curr_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
     if (curr_req == NULL) {
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomemreq");
     }
@@ -900,7 +900,7 @@ static int issue_cas_op(MPIDI_RMA_Op_t * rma_op,
     /* Create a request for the RMW response.  Store the origin buf, count, and
      * datatype in it, and pass the request's handle RMW packet. When the
      * response comes from the target, it will contain the request handle. */
-    curr_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+    curr_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
     MPIR_ERR_CHKANDJUMP(curr_req == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
 
     /* Set refs on the request to 2: one for the response message, and one for
@@ -959,7 +959,7 @@ static int issue_fop_op(MPIDI_RMA_Op_t * rma_op,
     /* Create a request for the GACC response.  Store the response buf, count, and
      * datatype in it, and pass the request's handle in the GACC packet. When the
      * response comes from the target, it will contain the request handle. */
-    resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+    resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
     MPIR_ERR_CHKANDJUMP(resp_req == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
 
     MPIR_Object_set_ref(resp_req, 2);

--- a/src/mpid/ch3/include/mpidimpl.h
+++ b/src/mpid/ch3/include/mpidimpl.h
@@ -265,7 +265,7 @@ extern MPIDI_Process_t MPIDI_Process;
 */
 #define MPIDI_Request_create_sreq(sreq_, mpi_errno_, FAIL_)	\
 {								\
-    (sreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);     \
+    (sreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);     \
     MPIR_Object_set_ref((sreq_), 2);				\
     (sreq_)->comm = comm;					\
     (sreq_)->dev.partner_request   = NULL;                         \
@@ -282,7 +282,7 @@ extern MPIDI_Process_t MPIDI_Process;
 /* This is the receive request version of MPIDI_Request_create_sreq */
 #define MPIDI_Request_create_rreq(rreq_, mpi_errno_, FAIL_)	\
 {								\
-    (rreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV, 0);           \
+    (rreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);           \
     MPIR_Object_set_ref((rreq_), 2);				\
     (rreq_)->dev.partner_request   = NULL;                         \
 }
@@ -291,7 +291,7 @@ extern MPIDI_Process_t MPIDI_Process;
  * returning when a user passed MPI_PROC_NULL */
 #define MPIDI_Request_create_null_rreq(rreq_, mpi_errno_, FAIL_)           \
     do {                                                                   \
-        (rreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV, 0);               \
+        (rreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);               \
         if ((rreq_) != NULL) {                                             \
             MPIR_Object_set_ref((rreq_), 1);                               \
             /* MT FIXME should these be handled by MPIR_Request_create? */ \

--- a/src/mpid/ch3/include/mpidrma.h
+++ b/src/mpid/ch3/include/mpidrma.h
@@ -417,7 +417,7 @@ static inline int enqueue_lock_origin(MPIR_Win * win_ptr, MPIDI_VC_t * vc,
         }
 
         /* create request to receive upcoming requests */
-        req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+        req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
         MPIR_Object_set_ref(req, 1);
 
         /* fill in area in req that will be used in Receive_data_found() */

--- a/src/mpid/ch3/src/ch3u_handle_recv_req.c
+++ b/src/mpid/ch3/src/ch3u_handle_recv_req.c
@@ -288,7 +288,7 @@ int MPIDI_CH3_ReqHandler_GaccumRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq
     MPIR_Datatype_is_contig(rreq->dev.datatype, &is_contig);
     MPIR_Datatype_get_true_lb(rreq->dev.datatype, &dt_true_lb);
 
-    resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+    resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
     MPIR_ERR_CHKANDJUMP(resp_req == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
     MPIR_Object_set_ref(resp_req, 1);
     MPIDI_Request_set_type(resp_req, MPIDI_REQUEST_TYPE_GET_ACCUM_RESP);
@@ -410,7 +410,7 @@ int MPIDI_CH3_ReqHandler_FOPRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
     MPIR_Datatype_is_contig(rreq->dev.datatype, &is_contig);
 
     /* Create response request */
-    resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+    resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
     MPIR_ERR_CHKANDJUMP(resp_req == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
     MPIDI_Request_set_type(resp_req, MPIDI_REQUEST_TYPE_FOP_RESP);
     MPIR_Object_set_ref(resp_req, 1);
@@ -785,7 +785,7 @@ int MPIDI_CH3_ReqHandler_GetDerivedDTRecvComplete(MPIDI_VC_t * vc,
     MPIR_Typerep_unflatten(new_dtp, rreq->dev.flattened_type);
 
     /* create request for sending data */
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
     MPIR_ERR_CHKANDJUMP(sreq == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
 
     sreq->kind = MPIR_REQUEST_KIND__SEND;
@@ -1010,7 +1010,7 @@ static inline int perform_get_in_lock_queue(MPIR_Win * win_ptr,
     /* Make sure that all data is received for this op. */
     MPIR_Assert(target_lock_entry->all_data_recved == 1);
 
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
     if (sreq == NULL) {
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomemreq");
     }
@@ -1183,7 +1183,7 @@ static inline int perform_get_acc_in_lock_queue(MPIR_Win * win_ptr,
     /* Make sure that all data is received for this op. */
     MPIR_Assert(target_lock_entry->all_data_recved == 1);
 
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
     if (sreq == NULL) {
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomemreq");
     }
@@ -1391,7 +1391,7 @@ static inline int perform_fop_in_lock_queue(MPIR_Win * win_ptr,
         fop_resp_pkt->pkt_flags |= MPIDI_CH3_PKT_FLAG_RMA_ACK;
 
     if (fop_pkt->type == MPIDI_CH3_PKT_FOP) {
-        resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+        resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
         if (resp_req == NULL) {
             MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomemreq");
         }

--- a/src/mpid/ch3/src/ch3u_rma_pkthandler.c
+++ b/src/mpid/ch3/src/ch3u_rma_pkthandler.c
@@ -279,7 +279,7 @@ int MPIDI_CH3_PktHandler_Put(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
         data_len = *buflen;
         data_buf = (char *) data;
 
-        req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+        req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
         MPIR_Object_set_ref(req, 1);
 
         req->dev.user_buf = put_pkt->addr;
@@ -411,7 +411,7 @@ int MPIDI_CH3_PktHandler_Get(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
         goto fn_exit;
     }
 
-    req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+    req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
     req->dev.target_win_handle = get_pkt->target_win_handle;
     req->dev.pkt_flags = get_pkt->pkt_flags;
 
@@ -633,7 +633,7 @@ int MPIDI_CH3_PktHandler_Accumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void
     else {
         MPIR_Assert(pkt->type == MPIDI_CH3_PKT_ACCUMULATE);
 
-        req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+        req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
         MPIR_Object_set_ref(req, 1);
         *rreqp = req;
 
@@ -832,7 +832,7 @@ int MPIDI_CH3_PktHandler_GetAccumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
         /* Immed packet type is used when target datatype is predefined datatype. */
         MPIR_Assert(MPIR_DATATYPE_IS_PREDEFINED(get_accum_pkt->datatype));
 
-        resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+        resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
         resp_req->dev.target_win_handle = get_accum_pkt->target_win_handle;
         resp_req->dev.pkt_flags = get_accum_pkt->pkt_flags;
 
@@ -907,7 +907,7 @@ int MPIDI_CH3_PktHandler_GetAccumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
 
         MPIR_Assert(pkt->type == MPIDI_CH3_PKT_GET_ACCUM);
 
-        req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+        req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
         MPIR_Object_set_ref(req, 1);
         *rreqp = req;
 
@@ -1352,7 +1352,7 @@ int MPIDI_CH3_PktHandler_FOP(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
         if (fop_pkt->op == MPI_NO_OP)
             is_empty_origin = TRUE;
 
-        req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
+        req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
         MPIR_Object_set_ref(req, 1);
         MPIDI_Request_set_type(req, MPIDI_REQUEST_TYPE_FOP_RECV);
         *rreqp = req;

--- a/src/mpid/ch3/src/ch3u_rma_reqops.c
+++ b/src/mpid/ch3/src/ch3u_rma_reqops.c
@@ -31,7 +31,7 @@ int MPID_Rput(const void *origin_addr, int origin_count,
     MPIDI_Datatype_get_info(origin_count, origin_datatype, dt_contig, data_sz, dtp, dt_true_lb);
 
     /* Create user request, initially cc=1, ref=1 */
-    ureq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
+    ureq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
     MPIR_ERR_CHKANDJUMP(ureq == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
 
     /* This request is referenced by user and ch3 by default. */
@@ -85,7 +85,7 @@ int MPID_Rget(void *origin_addr, int origin_count,
     MPIDI_Datatype_get_info(origin_count, origin_datatype, dt_contig, data_sz, dtp, dt_true_lb);
 
     /* Create user request, initially cc=1, ref=1 */
-    ureq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
+    ureq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
     MPIR_ERR_CHKANDJUMP(ureq == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
 
     /* This request is referenced by user and ch3 by default. */
@@ -137,7 +137,7 @@ int MPID_Raccumulate(const void *origin_addr, int origin_count,
                         mpi_errno, MPI_ERR_RMA_SYNC, "**rmasync");
 
     /* Create user request, initially cc=1, ref=1 */
-    ureq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
+    ureq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
     MPIR_ERR_CHKANDJUMP(ureq == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
 
     /* This request is referenced by user and ch3 by default. */
@@ -192,7 +192,7 @@ int MPID_Rget_accumulate(const void *origin_addr, int origin_count,
                         mpi_errno, MPI_ERR_RMA_SYNC, "**rmasync");
 
     /* Create user request, initially cc=1, ref=1 */
-    ureq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
+    ureq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
     MPIR_ERR_CHKANDJUMP(ureq == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
 
     /* This request is referenced by user and ch3 by default. */

--- a/src/mpid/ch3/src/mpid_startall.c
+++ b/src/mpid/ch3/src/mpid_startall.c
@@ -17,7 +17,7 @@
 /* This macro initializes all of the fields in a persistent request */
 #define MPIDI_Request_create_psreq(sreq_, mpi_errno_, FAIL_)		\
 {									\
-    (sreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_SEND, 0);                  \
+    (sreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_SEND);                  \
     if ((sreq_) == NULL)						\
     {									\
 	MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER,VERBOSE,"send request allocation failed");\
@@ -275,7 +275,7 @@ int MPID_Recv_init(void * buf, int count, MPI_Datatype datatype, int rank, int t
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_RECV_INIT);
     
-    rreq = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_RECV, 0);
+    rreq = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_RECV);
     if (rreq == NULL)
     {
 	/* --BEGIN ERROR HANDLING-- */

--- a/src/mpid/ch4/generic/am/mpidig_am_recv.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_recv.h
@@ -166,7 +166,7 @@ static inline int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Datatype dataty
                 MPIR_Request_add_ref(*request);
                 MPID_Request_complete(*request);
                 /* Need to free here because we don't return this to user */
-                MPIR_Request_free(unexp_req);
+                MPIR_Request_free_unsafe(unexp_req);
             }
             goto fn_exit;
         }

--- a/src/mpid/ch4/include/mpid_thread.h
+++ b/src/mpid/ch4/include/mpid_thread.h
@@ -18,6 +18,7 @@ typedef MPIDU_Thread_mutex_t MPID_Thread_mutex_t;
 #define MPID_THREAD_CS_ENTER       MPIDU_THREAD_CS_ENTER
 #define MPID_THREAD_CS_EXIT        MPIDU_THREAD_CS_EXIT
 #define MPID_THREAD_CS_YIELD       MPIDU_THREAD_CS_YIELD
+#define MPID_THREAD_ASSERT_IN_CS   MPIDU_THREAD_ASSERT_IN_CS
 
 #define MPID_Thread_init           MPIDU_Thread_init
 #define MPID_Thread_finalize       MPIDU_Thread_finalize

--- a/src/mpid/ch4/include/mpidpost.h
+++ b/src/mpid/ch4/include/mpidpost.h
@@ -29,6 +29,8 @@ MPL_STATIC_INLINE_PREFIX void MPID_Request_free_hook(MPIR_Request * req)
 
     MPL_atomic_fetch_add_int(&MPIDI_global.progress_count, 1);
 
+    /* This is tricky. I think the only solution is to expose partner
+     * to the upper layer */
     if (req->kind == MPIR_REQUEST_KIND__PREQUEST_RECV &&
         NULL != MPIDI_REQUEST_ANYSOURCE_PARTNER(req))
         MPIR_Request_free(MPIDI_REQUEST_ANYSOURCE_PARTNER(req));

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -401,7 +401,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_emulated_inject(fi_addr_t addr,
     char *ibuf;
     size_t len;
 
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    sreq = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0);
     MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     len = am_hdr_sz + sizeof(*msg_hdrp);
     ibuf = (char *) MPL_malloc(len, MPL_MEM_BUFFER);

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -401,7 +401,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_emulated_inject(fi_addr_t addr,
     char *ibuf;
     size_t len;
 
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
     MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     len = am_hdr_sz + sizeof(*msg_hdrp);
     ibuf = (char *) MPL_malloc(len, MPL_MEM_BUFFER);

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -310,7 +310,7 @@ int MPIDI_OFI_send_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq, int
             MPL_free(MPIDI_OFI_REQUEST(sreq, noncontig.nopack));
 
         MPIR_Datatype_release_if_not_builtin(MPIDI_OFI_REQUEST(sreq, datatype));
-        MPIR_Request_free(sreq);
+        MPIR_Request_free_unsafe(sreq);
     }
     /* c != 0, ssend */
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_SEND_EVENT);
@@ -356,7 +356,7 @@ static int send_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
         }
 
         MPIR_Datatype_release_if_not_builtin(MPIDI_OFI_REQUEST(sreq, datatype));
-        MPIR_Request_free(sreq);
+        MPIR_Request_free_unsafe(sreq);
     }
     /* c != 0, ssend */
   fn_exit:
@@ -459,7 +459,7 @@ static int chunk_done_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
     MPIR_cc_decr(creq->parent->cc_ptr, &c);
 
     if (c == 0)
-        MPIR_Request_free(creq->parent);
+        MPIR_Request_free_unsafe(creq->parent);
 
     MPL_free(creq);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_CHUNK_DONE_EVENT);
@@ -476,7 +476,7 @@ static int inject_emu_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
 
     if (!incomplete) {
         MPL_free(MPIDI_OFI_REQUEST(req, util.inject_buf));
-        MPIR_Request_free(req);
+        MPIR_Request_free_unsafe(req);
         MPL_atomic_fetch_sub_int(&MPIDI_OFI_global.am_inflight_inject_emus, 1);
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -193,7 +193,7 @@ int MPIDI_OFI_progress(int vci, int blocking);
 
 #define MPIDI_OFI_REQUEST_CREATE(req, kind)                 \
     do {                                                      \
-        (req) = MPIR_Request_create(kind);  \
+        (req) = MPIR_Request_create_from_pool(kind, 0);  \
         MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq"); \
         MPIR_Request_add_ref((req));                                \
     } while (0)
@@ -216,7 +216,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_need_request_creation(const MPIR_Request 
           if (MPIDI_OFI_need_request_creation(req)) {                   \
               MPIR_Assert(MPIDI_CH4_MT_MODEL == MPIDI_CH4_MT_DIRECT ||  \
                           (req) == NULL);                               \
-              (req) = MPIR_Request_create(kind);                        \
+              (req) = MPIR_Request_create_from_pool(kind, 0);           \
               MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, \
                                   "**nomemreq");                        \
           }                                                             \

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -193,7 +193,7 @@ int MPIDI_OFI_progress(int vci, int blocking);
 
 #define MPIDI_OFI_REQUEST_CREATE(req, kind)                 \
     do {                                                      \
-        (req) = MPIR_Request_create(kind, 0);  \
+        (req) = MPIR_Request_create(kind);  \
         MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq"); \
         MPIR_Request_add_ref((req));                                \
     } while (0)
@@ -216,7 +216,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_need_request_creation(const MPIR_Request 
           if (MPIDI_OFI_need_request_creation(req)) {                   \
               MPIR_Assert(MPIDI_CH4_MT_MODEL == MPIDI_CH4_MT_DIRECT ||  \
                           (req) == NULL);                               \
-              (req) = MPIR_Request_create(kind, 0);                        \
+              (req) = MPIR_Request_create(kind);                        \
               MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, \
                                   "**nomemreq");                        \
           }                                                             \

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -59,7 +59,7 @@ static inline int MPIDI_OFI_do_iprobe(int source,
     if (ofi_err == -FI_ENOMSG) {
         *flag = 0;
         if (message)
-            MPIR_Request_free(rreq);
+            MPIR_Request_free_unsafe(rreq);
         goto fn_exit;
     }
 
@@ -71,7 +71,7 @@ static inline int MPIDI_OFI_do_iprobe(int source,
             *flag = 0;
 
             if (message)
-                MPIR_Request_free(rreq);
+                MPIR_Request_free_unsafe(rreq);
 
             goto fn_exit;
             break;

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -33,7 +33,7 @@ static inline int MPIDI_OFI_do_iprobe(int source,
         remote_proc = MPIDI_OFI_av_to_phys(addr);
 
     if (message) {
-        rreq = MPIR_Request_create(MPIR_REQUEST_KIND__MPROBE, 0);
+        rreq = MPIR_Request_create(MPIR_REQUEST_KIND__MPROBE);
         MPIR_ERR_CHKANDSTMT((rreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     } else {
         rreq = &r;

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -33,7 +33,7 @@ static inline int MPIDI_OFI_do_iprobe(int source,
         remote_proc = MPIDI_OFI_av_to_phys(addr);
 
     if (message) {
-        rreq = MPIR_Request_create(MPIR_REQUEST_KIND__MPROBE);
+        rreq = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__MPROBE, 0);
         MPIR_ERR_CHKANDSTMT((rreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     } else {
         rreq = &r;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -1176,7 +1176,7 @@ static inline int MPIDI_OFI_do_get_accumulate(const void *origin_addr,
   null_op_exit:
     mpi_errno = MPI_SUCCESS;
     if (sigreq) {
-        *sigreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
+        *sigreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
         MPIR_ERR_CHKANDSTMT((*sigreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
                             "**nomemreq");
         MPIR_Request_add_ref(*sigreq);

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -1176,7 +1176,7 @@ static inline int MPIDI_OFI_do_get_accumulate(const void *origin_addr,
   null_op_exit:
     mpi_errno = MPI_SUCCESS;
     if (sigreq) {
-        *sigreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
+        *sigreq = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RMA, 0);
         MPIR_ERR_CHKANDSTMT((*sigreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
                             "**nomemreq");
         MPIR_Request_add_ref(*sigreq);

--- a/src/mpid/ch4/netmod/ucx/ucx_probe.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_probe.h
@@ -30,7 +30,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
 
     if (message_h) {
         *flag = 1;
-        req = (MPIR_Request *) MPIR_Request_create(MPIR_REQUEST_KIND__MPROBE, 0);
+        req = (MPIR_Request *) MPIR_Request_create(MPIR_REQUEST_KIND__MPROBE);
         MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
         MPIR_Request_add_ref(req);
         MPIDI_UCX_REQ(req).message_handler = message_h;

--- a/src/mpid/ch4/netmod/ucx/ucx_probe.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_probe.h
@@ -30,7 +30,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
 
     if (message_h) {
         *flag = 1;
-        req = (MPIR_Request *) MPIR_Request_create(MPIR_REQUEST_KIND__MPROBE);
+        req = (MPIR_Request *) MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__MPROBE, 0);
         MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
         MPIR_Request_add_ref(req);
         MPIDI_UCX_REQ(req).message_handler = message_h;

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -20,7 +20,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_recv_cmpl_cb(void *request, ucs_status_t
     if (ucp_request->req)
         rreq = ucp_request->req;
     else
-        rreq = MPIR_Request_create(MPIR_REQUEST_KIND__RECV, 0);
+        rreq = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
 
     if (unlikely(status == UCS_ERR_CANCELED)) {
         MPIR_STATUS_SET_CANCEL_BIT(rreq->status, TRUE);
@@ -140,7 +140,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_recv(void *buf,
         ucp_request_release(ucp_request);
     } else {
         if (req == NULL)
-            req = MPIR_Request_create(MPIR_REQUEST_KIND__RECV, 0);
+            req = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
         MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
         MPIR_Request_add_ref(req);
         MPIDI_UCX_REQ(req).ucp_request = ucp_request;

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -20,7 +20,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_recv_cmpl_cb(void *request, ucs_status_t
     if (ucp_request->req)
         rreq = ucp_request->req;
     else
-        rreq = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
+        rreq = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RECV, 0);
 
     if (unlikely(status == UCS_ERR_CANCELED)) {
         MPIR_STATUS_SET_CANCEL_BIT(rreq->status, TRUE);
@@ -140,7 +140,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_recv(void *buf,
         ucp_request_release(ucp_request);
     } else {
         if (req == NULL)
-            req = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
+            req = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RECV, 0);
         MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
         MPIR_Request_add_ref(req);
         MPIDI_UCX_REQ(req).ucp_request = ucp_request;

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -134,7 +134,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_recv(void *buf,
         } else {
             memcpy(&req->status, &((MPIR_Request *) ucp_request->req)->status, sizeof(MPI_Status));
             MPIR_cc_set(&req->cc, 0);
-            MPIR_Request_free((MPIR_Request *) ucp_request->req);
+            MPIR_Request_free_unsafe((MPIR_Request *) ucp_request->req);
         }
         ucp_request->req = NULL;
         ucp_request_release(ucp_request);

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -73,7 +73,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_put(const void *origin_addr,
         /* Create an MPI request and return. The completion cb will complete
          * the request and release ucp_request. */
         MPIR_Request *req = NULL;
-        req = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
+        req = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
         MPIR_ERR_CHKANDSTMT(req == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
         MPIR_Request_add_ref(req);
         ucp_request->req = req;
@@ -167,7 +167,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_get(void *origin_addr,
         /* Create an MPI request and return. The completion cb will complete
          * the request and release ucp_request. */
         MPIR_Request *req = NULL;
-        req = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
+        req = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
         MPIR_ERR_CHKANDSTMT(req == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
         MPIR_Request_add_ref(req);
         ucp_request->req = req;

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -73,7 +73,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_put(const void *origin_addr,
         /* Create an MPI request and return. The completion cb will complete
          * the request and release ucp_request. */
         MPIR_Request *req = NULL;
-        req = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
+        req = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RMA, 0);
         MPIR_ERR_CHKANDSTMT(req == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
         MPIR_Request_add_ref(req);
         ucp_request->req = req;
@@ -167,7 +167,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_get(void *origin_addr,
         /* Create an MPI request and return. The completion cb will complete
          * the request and release ucp_request. */
         MPIR_Request *req = NULL;
-        req = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
+        req = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RMA, 0);
         MPIR_ERR_CHKANDSTMT(req == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
         MPIR_Request_add_ref(req);
         ucp_request->req = req;

--- a/src/mpid/ch4/netmod/ucx/ucx_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_send.h
@@ -85,7 +85,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_send(const void *buf,
 
     if (ucp_request) {
         if (req == NULL)
-            req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
+            req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
         MPIR_Request_add_ref(req);
         ucp_request->req = req;
         MPIDI_UCX_REQ(req).ucp_request = ucp_request;

--- a/src/mpid/ch4/netmod/ucx/ucx_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_send.h
@@ -85,7 +85,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_send(const void *buf,
 
     if (ucp_request) {
         if (req == NULL)
-            req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+            req = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0);
         MPIR_Request_add_ref(req);
         ucp_request->req = req;
         MPIDI_UCX_REQ(req).ucp_request = ucp_request;

--- a/src/mpid/ch4/shm/posix/eager/fbox/func_table.c
+++ b/src/mpid/ch4/shm/posix/eager/fbox/func_table.c
@@ -3,7 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
-#ifndef POSIX_EAGER_INLINE
+#ifdef POSIX_EAGER_INLINE
+/* this file is empty */
+#else
+
 #define POSIX_EAGER_DISABLE_INLINES
 
 #include <mpidimpl.h>

--- a/src/mpid/ch4/shm/posix/eager/iqueue/func_table.c
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/func_table.c
@@ -3,7 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
-#ifndef POSIX_EAGER_INLINE
+#ifdef POSIX_EAGER_INLINE
+/* this file is empty */
+#else
+
 #define POSIX_EAGER_DISABLE_INLINES
 
 #include <mpidimpl.h>

--- a/src/mpid/ch4/shm/posix/eager/stub/func_table.c
+++ b/src/mpid/ch4/shm/posix/eager/stub/func_table.c
@@ -3,7 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
-#ifndef POSIX_EAGER_INLINE
+#ifdef POSIX_EAGER_INLINE
+/* this file is empty */
+#else
+
 #define POSIX_EAGER_DISABLE_INLINES
 
 #include <mpidimpl.h>

--- a/src/mpid/ch4/shm/posix/posix_rma.h
+++ b/src/mpid/ch4/shm/posix/posix_rma.h
@@ -362,7 +362,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_rput(const void *origin_addr,
     MPIR_ERR_CHECK(mpi_errno);
 
     /* create a completed request for user. */
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
+    sreq = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RMA, 0);
     MPIR_Assert(sreq);
 
     MPIR_Request_add_ref(sreq);
@@ -467,7 +467,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_raccumulate(const void *origin_addr
     MPIR_ERR_CHECK(mpi_errno);
 
     /* create a completed request for user. */
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
+    sreq = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RMA, 0);
     MPIR_Assert(sreq);
 
     MPIR_Request_add_ref(sreq);
@@ -516,7 +516,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_rget_accumulate(const void *origin_
     MPIR_ERR_CHECK(mpi_errno);
 
     /* create a completed request for user. */
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
+    sreq = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RMA, 0);
     MPIR_Assert(sreq);
 
     MPIR_Request_add_ref(sreq);
@@ -627,7 +627,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_rget(void *origin_addr,
     MPIR_ERR_CHECK(mpi_errno);
 
     /* create a completed request for user. */
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
+    sreq = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RMA, 0);
     MPIR_Assert(sreq);
 
     MPIR_Request_add_ref(sreq);

--- a/src/mpid/ch4/shm/posix/posix_rma.h
+++ b/src/mpid/ch4/shm/posix/posix_rma.h
@@ -362,7 +362,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_rput(const void *origin_addr,
     MPIR_ERR_CHECK(mpi_errno);
 
     /* create a completed request for user. */
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
     MPIR_Assert(sreq);
 
     MPIR_Request_add_ref(sreq);
@@ -467,7 +467,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_raccumulate(const void *origin_addr
     MPIR_ERR_CHECK(mpi_errno);
 
     /* create a completed request for user. */
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
     MPIR_Assert(sreq);
 
     MPIR_Request_add_ref(sreq);
@@ -516,7 +516,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_rget_accumulate(const void *origin_
     MPIR_ERR_CHECK(mpi_errno);
 
     /* create a completed request for user. */
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
     MPIR_Assert(sreq);
 
     MPIR_Request_add_ref(sreq);
@@ -627,7 +627,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_rget(void *origin_addr,
     MPIR_ERR_CHECK(mpi_errno);
 
     /* create a completed request for user. */
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
     MPIR_Assert(sreq);
 
     MPIR_Request_add_ref(sreq);

--- a/src/mpid/ch4/src/ch4_globals.c
+++ b/src/mpid/ch4/src/ch4_globals.c
@@ -21,7 +21,7 @@ struct MPIDI_workq_elemt MPIDI_workq_elemt_direct[MPIDI_WORKQ_ELEMT_PREALLOC];
 
 MPIR_Object_alloc_t MPIDI_workq_elemt_mem = {
     0, 0, 0, 0, MPIR_INTERNAL, sizeof(struct MPIDI_workq_elemt), MPIDI_workq_elemt_direct,
-    MPIDI_WORKQ_ELEMT_PREALLOC
+    MPIDI_WORKQ_ELEMT_PREALLOC, NULL
 };
 #endif /* #if defined(MPIDI_CH4_USE_WORK_QUEUES) */
 

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -357,7 +357,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_win_hash_clear(MPIR_Win * win)
 
 #define MPIDI_Request_create_null_rreq(rreq_, mpi_errno_, FAIL_)        \
     do {                                                                \
-        (rreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV, 0);         \
+        (rreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);         \
         if ((rreq_) != NULL) {                                          \
             MPIR_cc_set(&(rreq_)->cc, 0);                               \
             MPIR_Status_set_procnull(&(rreq_)->status);                 \

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -357,7 +357,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_win_hash_clear(MPIR_Win * win)
 
 #define MPIDI_Request_create_null_rreq(rreq_, mpi_errno_, FAIL_)        \
     do {                                                                \
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);                   \
         (rreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);         \
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);                    \
         if ((rreq_) != NULL) {                                          \
             MPIR_cc_set(&(rreq_)->cc, 0);                               \
             MPIR_Status_set_procnull(&(rreq_)->status);                 \

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -358,7 +358,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_win_hash_clear(MPIR_Win * win)
 #define MPIDI_Request_create_null_rreq(rreq_, mpi_errno_, FAIL_)        \
     do {                                                                \
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);                   \
-        (rreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);         \
+        (rreq_) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RECV, 0);         \
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);                    \
         if ((rreq_) != NULL) {                                          \
             MPIR_cc_set(&(rreq_)->cc, 0);                               \

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -108,7 +108,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIU_request_complete(MPIR_Request * req)
 
     MPIR_cc_decr(req->cc_ptr, &incomplete);
     if (!incomplete) {
-        MPIR_Request_free(req);
+        MPIR_Request_free_unsafe(req);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIU_REQUEST_COMPLETE);

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -564,8 +564,13 @@ int MPID_Init(int requested, int *provided)
     /* Initialize multiple VCIs */
     /* TODO: add checks to ensure MPIDI_vci_t is padded or aligned to MPL_CACHELINE_SIZE */
     MPIDI_global.n_vcis = 1;
-    if (MPIR_CVAR_CH4_NUM_VCIS > 1)
+    if (MPIR_CVAR_CH4_NUM_VCIS > 1) {
         MPIDI_global.n_vcis = MPIR_CVAR_CH4_NUM_VCIS;
+        /* There are configured maxes that we need observe. */
+        /* TODO: check them at configure time to avoid discrepancy */
+        MPIR_Assert(MPIDI_global.n_vcis <= MPIDI_CH4_MAX_VCIS);
+        MPIR_Assert(MPIDI_global.n_vcis <= MPIR_REQUEST_NUM_POOLS);
+    }
 
     for (int i = 0; i < MPIDI_global.n_vcis; i++) {
         MPID_Thread_mutex_create(&MPIDI_VCI(i).lock, &err);

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -575,6 +575,10 @@ int MPID_Init(int requested, int *provided)
     for (int i = 0; i < MPIDI_global.n_vcis; i++) {
         MPID_Thread_mutex_create(&MPIDI_VCI(i).lock, &err);
         MPIR_Assert(err == 0);
+
+        /* NOTE: 1-1 vci-pool mapping */
+        MPIR_Request_register_pool_lock(i, &MPIDI_VCI(i).lock);
+
         /* TODO: lw_req, workq */
     }
 

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -215,7 +215,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_recv_safe(void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RECV_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(RECV, NULL /*send_buf */ , buf, count, datatype,
@@ -252,7 +254,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_safe(void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IRECV_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(IRECV, NULL /*send_buf */ , buf, count, datatype,
@@ -283,7 +287,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_imrecv_safe(void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IMRECV_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     MPIR_Request *request = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHKANDSTMT(request == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(IMRECV, NULL /*send_buf */ , buf, count, datatype,
@@ -367,7 +373,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Recv_init(void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_RECV_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_RECV_INIT);
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     rreq = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_RECV);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
 
     *request = rreq;

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -48,7 +48,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_recv_unsafe(void *buf,
                 if (MPIR_STATUS_GET_CANCEL_BIT((*request)->status)) {
                     (*request)->status = MPIDI_REQUEST_ANYSOURCE_PARTNER(*request)->status;
                 }
-                MPIR_Request_free(MPIDI_REQUEST_ANYSOURCE_PARTNER(*request));
+                MPIR_Request_free_unsafe(MPIDI_REQUEST_ANYSOURCE_PARTNER(*request));
                 goto fn_exit;
             }
 
@@ -118,7 +118,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_unsafe(void *buf,
                 if (MPIR_STATUS_GET_CANCEL_BIT((*request)->status)) {
                     (*request)->status = MPIDI_REQUEST_ANYSOURCE_PARTNER(*request)->status;
                 }
-                MPIR_Request_free(MPIDI_REQUEST_ANYSOURCE_PARTNER(*request));
+                MPIR_Request_free_unsafe(MPIDI_REQUEST_ANYSOURCE_PARTNER(*request));
                 goto fn_exit;
             }
 
@@ -185,7 +185,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_cancel_recv_unsafe(MPIR_Request * rreq)
             /* Canceling MPI_ANY_SOURCE receive -- first cancel NM recv, then SHM */
             mpi_errno = MPIDI_NM_mpi_cancel_recv(partner_rreq);
             MPIR_ERR_CHECK(mpi_errno);
-            MPIR_Request_free(partner_rreq);
+            MPIR_Request_free_unsafe(partner_rreq);
         }
         mpi_errno = MPIDI_SHM_mpi_cancel_recv(rreq);
     } else {

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -215,7 +215,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_recv_safe(void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RECV_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV, 0);
+    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(RECV, NULL /*send_buf */ , buf, count, datatype,
@@ -252,7 +252,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_safe(void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IRECV_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV, 0);
+    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(IRECV, NULL /*send_buf */ , buf, count, datatype,
@@ -283,7 +283,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_imrecv_safe(void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IMRECV_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIR_Request *request = MPIR_Request_create(MPIR_REQUEST_KIND__RECV, 0);
+    MPIR_Request *request = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
     MPIR_ERR_CHKANDSTMT(request == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(IMRECV, NULL /*send_buf */ , buf, count, datatype,
@@ -367,7 +367,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Recv_init(void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_RECV_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_RECV_INIT);
 
-    rreq = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_RECV, 0);
+    rreq = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_RECV);
     MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
 
     *request = rreq;

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -216,7 +216,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_recv_safe(void *buf,
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
+    *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RECV, 0);
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
@@ -255,7 +255,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_safe(void *buf,
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
+    *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RECV, 0);
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
@@ -288,7 +288,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_imrecv_safe(void *buf,
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    MPIR_Request *request = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
+    MPIR_Request *request = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__RECV, 0);
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHKANDSTMT(request == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
@@ -374,7 +374,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Recv_init(void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_RECV_INIT);
 
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    rreq = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_RECV);
+    rreq = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__PREQUEST_RECV, 0);
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
 

--- a/src/mpid/ch4/src/ch4_request.h
+++ b/src/mpid/ch4/src/ch4_request.h
@@ -97,7 +97,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Request_complete(MPIR_Request * req)
             MPIDI_SHM_am_request_finalize(req);
 #endif
         }
-        MPIR_Request_free(req);
+        MPIR_Request_free_unsafe(req);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_REQUEST_COMPLETE);

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -250,7 +250,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_safe(const void *buf,
      *       if the lower layer expose the threshold.
      */
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0);
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
@@ -289,7 +289,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_coll_safe(const void *buf,
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0);
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
@@ -325,7 +325,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_safe(const void *buf,
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0);
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
@@ -364,7 +364,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_coll_safe(const void *buf,
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0);
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
@@ -400,7 +400,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_ssend_safe(const void *buf,
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0);
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
@@ -437,7 +437,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_issend_safe(const void *buf,
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    *(req) = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, 0);
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
@@ -690,7 +690,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_psend_init(MPIDI_ptype ptype,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_PSEND_INIT);
 
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_SEND);
+    sreq = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__PREQUEST_SEND, 0);
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     *request = sreq;

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -249,7 +249,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_safe(const void *buf,
      *       threshold for lightweight send is controlled by lower layer. It'll be nice
      *       if the lower layer expose the threshold.
      */
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
+    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(SEND, buf, NULL /*recv_buf */ , count, datatype,
@@ -286,7 +286,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_coll_safe(const void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SEND_COLL_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
+    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_csend_enqueue(CSEND, buf, count, datatype, rank, tag, comm,
@@ -320,7 +320,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_safe(const void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ISEND_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
+    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(ISEND, buf, NULL /*recv_buf */ , count, datatype,
@@ -357,7 +357,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_coll_safe(const void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ISEND_COLL_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
+    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_csend_enqueue(ICSEND, buf, count, datatype, rank, tag, comm,
@@ -391,7 +391,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_ssend_safe(const void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SSEND_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
+    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(SSEND, buf, NULL /*recv_buf */ , count, datatype,
@@ -426,7 +426,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_issend_safe(const void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ISSEND_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
+    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(SSEND, buf, NULL /*recv_buf */ , count, datatype,
@@ -677,7 +677,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_psend_init(MPIDI_ptype ptype,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_PSEND_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_PSEND_INIT);
 
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_SEND, 0);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_SEND);
     MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     *request = sreq;
 

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -249,7 +249,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_safe(const void *buf,
      *       threshold for lightweight send is controlled by lower layer. It'll be nice
      *       if the lower layer expose the threshold.
      */
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(SEND, buf, NULL /*recv_buf */ , count, datatype,
@@ -286,7 +288,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_coll_safe(const void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SEND_COLL_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_csend_enqueue(CSEND, buf, count, datatype, rank, tag, comm,
@@ -320,7 +324,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_safe(const void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ISEND_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(ISEND, buf, NULL /*recv_buf */ , count, datatype,
@@ -357,7 +363,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_coll_safe(const void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ISEND_COLL_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_csend_enqueue(ICSEND, buf, count, datatype, rank, tag, comm,
@@ -391,7 +399,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_ssend_safe(const void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SSEND_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(SSEND, buf, NULL /*recv_buf */ , count, datatype,
@@ -426,7 +436,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_issend_safe(const void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ISSEND_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(SSEND, buf, NULL /*recv_buf */ , count, datatype,
@@ -677,7 +689,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_psend_init(MPIDI_ptype ptype,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_PSEND_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_PSEND_INIT);
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
     sreq = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_SEND);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
     MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     *request = sreq;
 

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -250,7 +250,7 @@ static int recv_target_cmpl_cb(MPIR_Request * rreq)
         MPIR_Request_add_ref(sigreq);
         MPID_Request_complete(sigreq);
         /* Free the unexpected request on behalf of the user */
-        MPIR_Request_free(rreq);
+        MPIR_Request_free_unsafe(rreq);
     }
     MPID_Request_complete(rreq);
   fn_exit:
@@ -364,7 +364,7 @@ int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint
             if (unlikely(root_comm_again != NULL)) {
                 MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
                 MPL_free(MPIDIG_REQUEST(rreq, buffer));
-                MPIR_Request_free(rreq);
+                MPIR_Request_free_unsafe(rreq);
                 MPID_Request_complete(rreq);
                 rreq = NULL;
                 root_comm = root_comm_again;
@@ -478,7 +478,7 @@ int MPIDIG_send_long_req_target_msg_cb(int handler_id, void *am_hdr, void *data,
             if (unlikely(root_comm_again != NULL)) {
                 MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
                 MPL_free(MPIDIG_REQUEST(rreq, buffer));
-                MPIR_Request_free(rreq);
+                MPIR_Request_free_unsafe(rreq);
                 MPID_Request_complete(rreq);
                 rreq = NULL;
                 root_comm = root_comm_again;

--- a/src/mpid/ch4/src/ch4r_request.h
+++ b/src/mpid/ch4/src/ch4r_request.h
@@ -17,7 +17,7 @@ static inline MPIR_Request *MPIDIG_request_create(MPIR_Request_kind_t kind, int 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_REQUEST_CREATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_REQUEST_CREATE);
 
-    req = MPIR_Request_create(kind);
+    req = MPIR_Request_create_from_pool(kind, 0);
     if (req == NULL)
         goto fn_fail;
 

--- a/src/mpid/ch4/src/ch4r_request.h
+++ b/src/mpid/ch4/src/ch4r_request.h
@@ -108,7 +108,7 @@ static inline int MPIDI_anysrc_try_cancel_partner(MPIR_Request * rreq, int *is_c
                     MPIDI_REQUEST_ANYSOURCE_PARTNER(rreq) = NULL;
                     MPIDI_REQUEST_ANYSOURCE_PARTNER(anysrc_partner) = NULL;
                     /* cancel freed it once, freed once more on behalf of mpi-layer */
-                    MPIR_Request_free(anysrc_partner);
+                    MPIR_Request_free_unsafe(anysrc_partner);
                 }
             } else {
                 /* NM, cancel SHM partner */
@@ -147,7 +147,7 @@ static inline void MPIDI_anysrc_free_partner(MPIR_Request * rreq)
              * final free for NM request happen at call-site MPID_Request_complete
              * final free for SHM partner happen at mpi-layer
              */
-            MPIR_Request_free(rreq);
+            MPIR_Request_free_unsafe(rreq);
         } else {
             /* SHM, NM partner should already been freed (this branch can't happen) */
             MPIR_Assert(0);

--- a/src/mpid/ch4/src/ch4r_request.h
+++ b/src/mpid/ch4/src/ch4r_request.h
@@ -17,7 +17,7 @@ static inline MPIR_Request *MPIDIG_request_create(MPIR_Request_kind_t kind, int 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_REQUEST_CREATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_REQUEST_CREATE);
 
-    req = MPIR_Request_create(kind, 0);
+    req = MPIR_Request_create(kind);
     if (req == NULL)
         goto fn_fail;
 

--- a/src/mpid/ch4/src/ch4r_rma.h
+++ b/src/mpid/ch4/src/ch4r_rma.h
@@ -158,7 +158,7 @@ static inline int MPIDIG_do_put(const void *origin_addr, int origin_count,
     if (sreq_ptr)
         *sreq_ptr = sreq;
     else if (sreq != NULL)
-        MPIR_Request_free(sreq);
+        MPIR_Request_free_unsafe(sreq);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_DO_PUT);
     return mpi_errno;
@@ -281,7 +281,7 @@ static inline int MPIDIG_do_get(void *origin_addr, int origin_count, MPI_Datatyp
     if (sreq_ptr)
         *sreq_ptr = sreq;
     else if (sreq != NULL)
-        MPIR_Request_free(sreq);
+        MPIR_Request_free_unsafe(sreq);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_DO_GET);
     return mpi_errno;
@@ -448,7 +448,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
     if (sreq_ptr)
         *sreq_ptr = sreq;
     else if (sreq != NULL)
-        MPIR_Request_free(sreq);
+        MPIR_Request_free_unsafe(sreq);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_DO_ACCUMULATE);
     return mpi_errno;
@@ -629,7 +629,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
     if (sreq_ptr)
         *sreq_ptr = sreq;
     else if (sreq != NULL)
-        MPIR_Request_free(sreq);
+        MPIR_Request_free_unsafe(sreq);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_DO_GET_ACCUMULATE);
     return mpi_errno;

--- a/src/mpid/common/hcoll/hcoll_rte.c
+++ b/src/mpid/common/hcoll/hcoll_rte.c
@@ -267,7 +267,7 @@ static int group_id(rte_grp_handle_t group)
 static void *get_coll_handle(void)
 {
     MPIR_Request *req;
-    req = MPIR_Request_create(MPIR_REQUEST_KIND__COLL, 0);
+    req = MPIR_Request_create(MPIR_REQUEST_KIND__COLL);
     MPIR_Request_add_ref(req);
     return (void *) req;
 }

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -470,7 +470,7 @@ int MPIDU_Sched_start(MPIR_Sched_t * sp, MPIR_Comm * comm, int tag, MPIR_Request
     MPIR_Assert(s->entries != NULL);
 
     /* now create and populate the request */
-    r = MPIR_Request_create(MPIR_REQUEST_KIND__COLL, 0);
+    r = MPIR_Request_create(MPIR_REQUEST_KIND__COLL);
     if (!r)
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
     /* FIXME is this right when comm/datatype GC is used? */

--- a/src/mpid/common/thread/mpidu_thread_fallback.h
+++ b/src/mpid/common/thread/mpidu_thread_fallback.h
@@ -153,12 +153,11 @@ M*/
             MPL_thread_id_t self_;                                      \
             MPL_thread_self(&self_);                                    \
             MPL_thread_same(&self_, &mutex.owner, &equal_);             \
-            if (equal_ && mutex.count > 0) {                            \
-                MPL_DBG_MSG_P(MPIR_DBG_THREAD,VERBOSE,"enter MPIDU_Thread_yield %p", &mutex); \
-                MPIDU_Thread_yield(&mutex, &err_);                          \
-                MPL_DBG_MSG_P(MPIR_DBG_THREAD,VERBOSE,"exit MPIDU_Thread_yield %p", &mutex); \
-                MPIR_Assert(err_ == 0);                                 \
-            }                                                           \
+            MPIR_Assert(equal_ && mutex.count > 0);                     \
+            MPL_DBG_MSG_P(MPIR_DBG_THREAD,VERBOSE,"enter MPIDU_Thread_yield %p", &mutex); \
+            MPIDU_Thread_yield(&mutex, &err_);                          \
+            MPL_DBG_MSG_P(MPIR_DBG_THREAD,VERBOSE,"exit MPIDU_Thread_yield %p", &mutex); \
+            MPIR_Assert(err_ == 0);                                     \
         }                                                               \
     } while (0)
 

--- a/src/mpl/include/mpl_trmem.h
+++ b/src/mpl/include/mpl_trmem.h
@@ -262,10 +262,29 @@ typedef struct {
 
 #else /* MPL_USE_MEMORY_TRACING */
 /* No memory tracing; just use native functions */
-#define MPL_malloc(a,b)    malloc((size_t)(a))
-#define MPL_calloc(a,b,c)  calloc((size_t)(a),(size_t)(b))
+/* size_t allows for larger values than PTRDIFF_MAX.  GCC throws a
+ * warning if we pass a signed integer to MPL_malloc and friends,
+ * which when typecast to size_t becomes a very large number, saying
+ * that the max size exceeds that of PTRDIFF_MAX. */
+static inline void *MPL_malloc(size_t size, MPL_memory_class memclass)
+{
+    assert(size <= PTRDIFF_MAX);
+    return malloc(size);
+}
+
+static inline void *MPL_calloc(size_t nmemb, size_t size, MPL_memory_class memclass)
+{
+    assert(size <= PTRDIFF_MAX);
+    return calloc(nmemb, size);
+}
+
+static inline void *MPL_realloc(void *ptr, size_t size, MPL_memory_class memclass)
+{
+    assert(size <= PTRDIFF_MAX);
+    return realloc(ptr, size);
+}
+
 #define MPL_free(a)      free((void *)(a))
-#define MPL_realloc(a,b,c)  realloc((void *)(a),(size_t)(b))
 #define MPL_mmap(a,b,c,d,e,f,g) mmap((void *)(a),(size_t)(b),(int)(c),(int)(d),(int)(e),(off_t)(f))
 #define MPL_munmap(a,b,c)  munmap((void *)(a),(size_t)(b))
 


### PR DESCRIPTION
## Pull Request Description

GCC seems to have an overly aggressive check to see the maximum bounds
of each variable.  When an integer is passed to the allocation, in
theory, it could have a negative value (which, when cast to size_t
becomes a very large value).  GCC complains about this case with
[-Walloc-size-larger-than=].  This patch converts the compile-time
check to a runtime check.

This is somewhat of a hack fix, because the correct fix would be to
change the calling site so that there is no implicit cast from a
signed integer to size_t.  But that would create a lot of code churn,
which this patch is trying to avoid.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
