### PR TITLE
datatype: fix alignment code

### DIFF
--- a/confdb/aclocal_cc.m4
+++ b/confdb/aclocal_cc.m4
@@ -1088,11 +1088,7 @@ int main( int argc, char *argv[] )
     if (extent1 < extent2) extent1 = extent2;
     if ((sizeof(double) == 8) && (extent1 % 8) != 0) {
        if (extent1 % 4 == 0) {
-#ifdef HAVE_MAX_FP_ALIGNMENT
-          if (HAVE_MAX_FP_ALIGNMENT >= 8) align_4 = 1;
-#else
           align_4 = 1;
-#endif
        }
     }
 

--- a/configure.ac
+++ b/configure.ac
@@ -3009,100 +3009,15 @@ if test "$MPID_NO_FLOAT16" != "yes" ; then
         AC_DEFINE(HAVE_FLOAT16,1,[Define if _Float16 is supported])
     fi
 fi
+
 # ----------------------------------------------------------------------------
-# Get default structure alignment for integers
-dnl PAC_C_MAX_INTEGER_ALIGN places the default alignment into
-dnl pac_cv_c_max_integer_align, with possible values including
-dnl packed (byte), largest, two, four, eight (or other failure message).
-PAC_C_MAX_INTEGER_ALIGN
+AC_CHECK_SIZEOF([max_align_t],[0],[#include <stddef.h>])
 
-if test "$pac_cv_c_max_integer_align" = "packed" ; then
-    pac_cv_c_struct_align_nr=1
-elif test "$pac_cv_c_max_integer_align" = "two" ; then
-    pac_cv_c_struct_align_nr=2
-elif test "$pac_cv_c_max_integer_align" = "four" ; then
-    pac_cv_c_struct_align_nr=4
-elif test "$pac_cv_c_max_integer_align" = "eight" ; then
-    pac_cv_c_struct_align_nr=8
-fi
-
-if test -n "$pac_cv_c_struct_align_nr" ; then
-    AC_DEFINE_UNQUOTED(HAVE_MAX_INTEGER_ALIGNMENT,$pac_cv_c_struct_align_nr,[Controls byte alignment of integer structures (for MPI structs)])
-    AC_DEFINE_UNQUOTED(HAVE_MAX_STRUCT_ALIGNMENT,$pac_cv_c_struct_align_nr,[Controls byte alignment of structures (for aligning allocated structures)])
-fi
-# Get default structure alignment for floating point types
-dnl PAC_C_MAX_FP_ALIGN places the default alignment into
-dnl pac_cv_c_max_fp_align, with possible values including
-dnl packed (byte), largest, two, four, eight (or other failure message).
-PAC_C_MAX_FP_ALIGN
-
-if test "$pac_cv_c_max_fp_align" = "packed" ; then
-    pac_cv_c_fp_align_nr=1
-elif test "$pac_cv_c_max_fp_align" = "two" ; then
-    pac_cv_c_fp_align_nr=2
-elif test "$pac_cv_c_max_fp_align" = "four" ; then
-    pac_cv_c_fp_align_nr=4
-elif test "$pac_cv_c_max_fp_align" = "eight" ; then
-    pac_cv_c_fp_align_nr=8
-elif test "$pac_cv_c_max_fp_align" = "sixteen" ; then
-    pac_cv_c_fp_align_nr=16
-elif test "$pac_cv_c_max_fp_align" = "largest" ; then
-    AC_MSG_ERROR([Configure detected unsupported structure alignment rules.])
-fi
-
-if test -n "$pac_cv_c_fp_align_nr" ; then
-    AC_DEFINE_UNQUOTED(HAVE_MAX_FP_ALIGNMENT,$pac_cv_c_fp_align_nr,[Controls byte alignment of structures with floats, doubles, and long doubles (for MPI structs)])
-fi
-
-# Test for the alignment of structs containing only long doubles.
-if test "$pac_cv_have_long_double" = yes ; then
-    # Check for alignment of just float and double (no long doubles)
-    PAC_C_MAX_DOUBLE_FP_ALIGN
-    PAC_C_MAX_LONGDOUBLE_FP_ALIGN
-    # FIXME: If this alignment is not the same as that for all float types,
-    # we need to do something else in the alignment rule code.
-    if test "$pac_cv_c_max_fp_align" != "$pac_cv_c_max_longdouble_fp_align" -o \
-            "$pac_cv_c_max_fp_align" != "$pac_cv_c_max_double_fp_align" ; then
-        AC_MSG_WARN([Structures containing long doubles may be aligned differently from structures with floats or longs.  MPICH does not handle this case automatically and you should avoid assumed extents for structures containing float types.])
-
-	double_align=-1
-	case $pac_cv_c_max_double_fp_align in
-	packed) double_align=1 ;;
-	two)    double_align=2 ;;
-	four)   double_align=4 ;;
-	eight)  double_align=8 ;;
-	esac
-	longdouble_align=-1
-	case $pac_cv_c_max_longdouble_fp_align in
-	packed) longdouble_align=1 ;;
-	two)    longdouble_align=2 ;;
-	four)   longdouble_align=4 ;;
-	eight)  longdouble_align=8 ;;
-	sixteen)longdouble_align=16 ;;
-	esac
-
-	AC_DEFINE_UNQUOTED(HAVE_MAX_DOUBLE_FP_ALIGNMENT,$double_align,[Controls byte alignment of structs with doubles])
-	AC_DEFINE_UNQUOTED(HAVE_MAX_LONG_DOUBLE_FP_ALIGNMENT,$longdouble_align,[Controls byte alignment of structs with long doubles])
-    fi
-fi
-
-# Test for weird struct alignment rules that vary padding based on
-# size of leading type only.
-PAC_C_DOUBLE_POS_ALIGN
-if test "$pac_cv_c_double_pos_align" = "yes" ; then
-    AC_DEFINE_UNQUOTED(HAVE_DOUBLE_POS_ALIGNMENT,1,[Controls how alignment is applied based on position of doubles in the structure])
-fi
-
-# Test for same weird issues with long long int.
-PAC_C_LLINT_POS_ALIGN
-if test "$pac_cv_c_llint_pos_align" = "yes" ; then
-   AC_DEFINE_UNQUOTED(HAVE_LLINT_POS_ALIGNMENT,1,[Controls how alignment is applied based on position of long long ints in the structure])
-fi
-
-# Test for double alignment not following all our other carefully constructed rules
-PAC_C_DOUBLE_ALIGNMENT_EXCEPTION
-if test "$pac_cv_c_double_alignment_exception" = "four" ; then
-   AC_DEFINE_UNQUOTED(HAVE_DOUBLE_ALIGNMENT_EXCEPTION,4,[Controls how alignment of doubles is performed, separate from other FP values])
+if test "$ac_cv_sizeof_max_align_t" != "0" ; then
+    AC_DEFINE_UNQUOTED(MAX_ALIGNMENT,$ac_cv_sizeof_max_align_t,[Controls byte alignment of structures (for aligning allocated structures)])
+else
+    AC_CHECK_ALIGNOF(long double)
+    AC_DEFINE_UNQUOTED(MAX_ALIGNMENT,$ac_cv_alignof_long_double,[Controls byte alignment of structures (for aligning allocated structures)])
 fi
 
 # Require strict alignment memory access for alignment-sensitive platform (e.g., SPARC)
@@ -3145,6 +3060,22 @@ AC_CHECK_SIZEOF(long_int, 0, [typedef struct { long a; int b; } long_int; ])
 AC_CHECK_SIZEOF(short_int, 0, [typedef struct { short a; int b; } short_int; ])
 AC_CHECK_SIZEOF(two_int, 0, [typedef struct { int a; int b; } two_int; ])
 AC_CHECK_SIZEOF(long_double_int, 0, [typedef struct { long double a; int b;} long_double_int; ])
+
+# alignments for basic types
+AC_CHECK_ALIGNOF(char)
+AC_CHECK_ALIGNOF(float)
+AC_CHECK_ALIGNOF(double)
+AC_CHECK_ALIGNOF(long)
+AC_CHECK_ALIGNOF(long long)
+AC_CHECK_ALIGNOF(long double)
+AC_CHECK_ALIGNOF(short)
+AC_CHECK_ALIGNOF(int)
+AC_CHECK_ALIGNOF(int8_t)
+AC_CHECK_ALIGNOF(int16_t)
+AC_CHECK_ALIGNOF(int32_t)
+AC_CHECK_ALIGNOF(int64_t)
+AC_CHECK_ALIGNOF(bool)
+AC_CHECK_ALIGNOF(wchar_t, 0, [#include <stddef.h>])
 
 # sys/bitypes.h defines the int16_t etc. on some systems (e.g., OSF1).
 # Include it when testing for these types

--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -354,12 +354,12 @@ void MPIR_Datatype_get_flattened(MPI_Datatype type, void **flattened, int *flatt
 static inline void MPIR_Datatype_free_contents(MPIR_Datatype * dtp)
 {
     int i, struct_sz = sizeof(MPIR_Datatype_contents);
-    int align_sz = 8, epsilon;
+    int epsilon;
     MPIR_Datatype *old_dtp;
     MPI_Datatype *array_of_types;
 
-    if ((epsilon = struct_sz % align_sz)) {
-        struct_sz += align_sz - epsilon;
+    if ((epsilon = struct_sz % MAX_ALIGNMENT)) {
+        struct_sz += MAX_ALIGNMENT - epsilon;
     }
 
     /* note: relies on types being first after structure */
@@ -391,17 +391,11 @@ static inline int MPIR_Datatype_set_contents(MPIR_Datatype * new_dtp,
                                              const MPI_Aint array_of_aints[],
                                              const MPI_Datatype array_of_types[])
 {
-    int i, contents_size, align_sz, epsilon, mpi_errno;
+    int i, contents_size, epsilon, mpi_errno;
     int struct_sz, ints_sz, aints_sz, types_sz;
     MPIR_Datatype_contents *cp;
     MPIR_Datatype *old_dtp;
     char *ptr;
-
-#ifdef HAVE_MAX_STRUCT_ALIGNMENT
-    align_sz = HAVE_MAX_STRUCT_ALIGNMENT;
-#else
-    align_sz = 8;
-#endif
 
     struct_sz = sizeof(MPIR_Datatype_contents);
     types_sz = nr_types * sizeof(MPI_Datatype);
@@ -413,14 +407,14 @@ static inline int MPIR_Datatype_set_contents(MPIR_Datatype * new_dtp,
      * note: it's not necessary that we pad the aints,
      *       because they are last in the region.
      */
-    if ((epsilon = struct_sz % align_sz)) {
-        struct_sz += align_sz - epsilon;
+    if ((epsilon = struct_sz % MAX_ALIGNMENT)) {
+        struct_sz += MAX_ALIGNMENT - epsilon;
     }
-    if ((epsilon = types_sz % align_sz)) {
-        types_sz += align_sz - epsilon;
+    if ((epsilon = types_sz % MAX_ALIGNMENT)) {
+        types_sz += MAX_ALIGNMENT - epsilon;
     }
-    if ((epsilon = ints_sz % align_sz)) {
-        ints_sz += align_sz - epsilon;
+    if ((epsilon = ints_sz % MAX_ALIGNMENT)) {
+        ints_sz += MAX_ALIGNMENT - epsilon;
     }
 
     contents_size = struct_sz + types_sz + ints_sz + aints_sz;

--- a/src/mpi/datatype/datatype.h
+++ b/src/mpi/datatype/datatype.h
@@ -9,6 +9,7 @@
 #include "mpiimpl.h"
 
 /* Definitions private to the datatype code */
+int MPIR_Datatype_builtintype_alignment(MPI_Datatype type);
 extern int MPIR_Datatype_init_predefined(void);
 extern int MPIR_Datatype_commit_pairtypes(void);
 extern void MPIR_Datatype_iscontig(MPI_Datatype, int *);

--- a/src/mpi/datatype/type_create_pairtype.c
+++ b/src/mpi/datatype/type_create_pairtype.c
@@ -10,8 +10,8 @@
 /* PAIRTYPE_SIZE_EXTENT - calculates size, extent, etc. for pairtype by
  * defining the appropriate C type.
  */
-#define PAIRTYPE_SIZE_EXTENT(mt1_,ut1_,mt2_,ut2_, type_size_, type_extent_, \
-                             el_size_, true_ub_, alignsize_)            \
+#define PAIRTYPE_SIZE_EXTENT(ut1_,ut2_, type_size_, type_extent_,       \
+                             el_size_, true_ub_)                        \
     {                                                                   \
         struct { ut1_ a; ut2_ b; } foo;                                 \
         type_size_   = sizeof(foo.a) + sizeof(foo.b);                   \
@@ -19,8 +19,6 @@
         el_size_ = (sizeof(foo.a) == sizeof(foo.b)) ? (int) sizeof(foo.a) : -1; \
         true_ub_ = ((MPI_Aint) ((char *) &foo.b - (char *) &foo.a)) +   \
             (MPI_Aint) sizeof(foo.b);                                   \
-        alignsize_ = MPL_MAX(MPIR_Datatype_get_basic_size(mt1_),        \
-                             MPIR_Datatype_get_basic_size(mt2_));       \
     }
 
 /*@
@@ -77,24 +75,24 @@ int MPIR_Type_create_pairtype(MPI_Datatype type, MPIR_Datatype * new_dtp)
 
     switch (type) {
         case MPI_FLOAT_INT:
-            PAIRTYPE_SIZE_EXTENT(MPI_FLOAT, float, MPI_INT, int,
-                                 type_size, type_extent, el_size, true_ub, alignsize);
+            PAIRTYPE_SIZE_EXTENT(float, int, type_size, type_extent, el_size, true_ub);
+            alignsize = MPL_MAX(ALIGNOF_FLOAT, ALIGNOF_INT);
             break;
         case MPI_DOUBLE_INT:
-            PAIRTYPE_SIZE_EXTENT(MPI_DOUBLE, double, MPI_INT, int,
-                                 type_size, type_extent, el_size, true_ub, alignsize);
+            PAIRTYPE_SIZE_EXTENT(double, int, type_size, type_extent, el_size, true_ub);
+            alignsize = MPL_MAX(ALIGNOF_DOUBLE, ALIGNOF_INT);
             break;
         case MPI_LONG_INT:
-            PAIRTYPE_SIZE_EXTENT(MPI_LONG, long, MPI_INT, int,
-                                 type_size, type_extent, el_size, true_ub, alignsize);
+            PAIRTYPE_SIZE_EXTENT(long, int, type_size, type_extent, el_size, true_ub);
+            alignsize = ALIGNOF_LONG;
             break;
         case MPI_SHORT_INT:
-            PAIRTYPE_SIZE_EXTENT(MPI_SHORT, short, MPI_INT, int,
-                                 type_size, type_extent, el_size, true_ub, alignsize);
+            PAIRTYPE_SIZE_EXTENT(short, int, type_size, type_extent, el_size, true_ub);
+            alignsize = ALIGNOF_INT;
             break;
         case MPI_LONG_DOUBLE_INT:
-            PAIRTYPE_SIZE_EXTENT(MPI_LONG_DOUBLE, long double, MPI_INT, int,
-                                 type_size, type_extent, el_size, true_ub, alignsize);
+            PAIRTYPE_SIZE_EXTENT(long double, int, type_size, type_extent, el_size, true_ub);
+            alignsize = MPL_MAX(ALIGNOF_LONG_DOUBLE, ALIGNOF_INT);
             break;
         default:
             /* --BEGIN ERROR HANDLING-- */
@@ -120,35 +118,10 @@ int MPIR_Type_create_pairtype(MPI_Datatype type, MPIR_Datatype * new_dtp)
     new_dtp->extent = type_extent;
     new_dtp->alignsize = alignsize;
 
-    /* place maximum on alignment based on padding rules */
-    /* There are some really wierd rules for structure alignment;
-     * these capture the ones of which we are aware. */
-    switch (type) {
-        case MPI_SHORT_INT:
-        case MPI_LONG_INT:
-#ifdef HAVE_MAX_INTEGER_ALIGNMENT
-            new_dtp->alignsize = MPL_MIN(new_dtp->alignsize, HAVE_MAX_INTEGER_ALIGNMENT);
-#endif
-            break;
-        case MPI_FLOAT_INT:
-#ifdef HAVE_MAX_FP_ALIGNMENT
-            new_dtp->alignsize = MPL_MIN(new_dtp->alignsize, HAVE_MAX_FP_ALIGNMENT);
-#endif
-            break;
-        case MPI_DOUBLE_INT:
-#ifdef HAVE_MAX_DOUBLE_FP_ALIGNMENT
-            new_dtp->alignsize = MPL_MIN(new_dtp->alignsize, HAVE_MAX_DOUBLE_FP_ALIGNMENT);
-#elif defined(HAVE_MAX_FP_ALIGNMENT)
-            new_dtp->alignsize = MPL_MIN(new_dtp->alignsize, HAVE_MAX_FP_ALIGNMENT);
-#endif
-            break;
-        case MPI_LONG_DOUBLE_INT:
-#ifdef HAVE_MAX_LONG_DOUBLE_FP_ALIGNMENT
-            new_dtp->alignsize = MPL_MIN(new_dtp->alignsize, HAVE_MAX_LONG_DOUBLE_FP_ALIGNMENT);
-#elif defined(HAVE_MAX_FP_ALIGNMENT)
-            new_dtp->alignsize = MPL_MIN(new_dtp->alignsize, HAVE_MAX_FP_ALIGNMENT);
-#endif
-            break;
+    MPI_Aint epsilon = type_extent % alignsize;
+    if (epsilon) {
+        new_dtp->ub += alignsize - epsilon;
+        new_dtp->extent += alignsize - epsilon;
     }
 
     new_dtp->is_contig = (((MPI_Aint) type_size) == type_extent) ? 1 : 0;

--- a/src/mpi/datatype/type_struct.c
+++ b/src/mpi/datatype/type_struct.c
@@ -27,103 +27,20 @@ int MPI_Type_struct(int count, int *array_of_blocklengths,
 #undef MPI_Type_struct
 #define MPI_Type_struct PMPI_Type_struct
 
-static MPI_Aint MPII_Type_struct_alignsize(int count,
-                                           const MPI_Datatype * oldtype_array,
-                                           const MPI_Aint * displacement_array);
-
-/* MPII_Type_struct_alignsize
- *
- * This function guesses at how the C compiler would align a structure
- * with the given components.
- *
- * It uses these configure-time defines to do its magic:
- * - HAVE_MAX_INTEGER_ALIGNMENT - maximum byte alignment of integers
- * - HAVE_MAX_FP_ALIGNMENT      - maximum byte alignment of floating points
- * - HAVE_MAX_LONG_DOUBLE_FP_ALIGNMENT - maximum byte alignment with long
- *                                   doubles (if different from FP_ALIGNMENT)
- * - HAVE_MAX_DOUBLE_FP_ALIGNMENT - maximum byte alignment with doubles (if
- *                                  long double is different from FP_ALIGNMENT)
- * - HAVE_DOUBLE_POS_ALIGNMENT  - indicates that structures with doubles
- *                                are aligned differently if double isn't
- *                                at displacement 0 (e.g. PPC32/64).
- * - HAVE_LLINT_POS_ALIGNMENT   - same as above, for MPI_LONG_LONG_INT
- *
- * The different FP, DOUBLE, LONG_DOUBLE alignment case are necessary for
- * Cygwin on X86 (because long_double is 12 bytes, so double and long double
- * have different natural alignments).  Linux on X86, however, does not have
- * different rules for this case.
- */
-static MPI_Aint MPII_Type_struct_alignsize(int count,
-                                           const MPI_Datatype * oldtype_array,
-                                           const MPI_Aint * displacement_array)
+static MPI_Aint struct_alignsize(int count, const MPI_Datatype * oldtype_array)
 {
-    int i;
-    MPI_Aint max_alignsize = 0, tmp_alignsize, derived_alignsize = 0;
+    MPI_Aint max_alignsize = 0, tmp_alignsize;
 
-    for (i = 0; i < count; i++) {
+    for (int i = 0; i < count; i++) {
         if (HANDLE_IS_BUILTIN(oldtype_array[i])) {
-            tmp_alignsize = MPIR_Datatype_get_basic_size(oldtype_array[i]);
-
-#ifdef HAVE_DOUBLE_ALIGNMENT_EXCEPTION
-            if (oldtype_array[i] == MPI_DOUBLE) {
-                tmp_alignsize = HAVE_DOUBLE_ALIGNMENT_EXCEPTION;
-            }
-#endif
-
-            switch (oldtype_array[i]) {
-                case MPI_FLOAT:
-                case MPI_DOUBLE:
-                case MPI_LONG_DOUBLE:
-#if defined(HAVE_MAX_LONG_DOUBLE_FP_ALIGNMENT) && \
-    defined(HAVE_MAX_DOUBLE_FP_ALIGNMENT)
-                    if (oldtype_array[i] == MPI_LONG_DOUBLE) {
-                        if (tmp_alignsize > HAVE_MAX_LONG_DOUBLE_FP_ALIGNMENT)
-                            tmp_alignsize = HAVE_MAX_LONG_DOUBLE_FP_ALIGNMENT;
-                    } else if (oldtype_array[i] == MPI_DOUBLE) {
-                        if (tmp_alignsize > HAVE_MAX_DOUBLE_FP_ALIGNMENT)
-                            tmp_alignsize = HAVE_MAX_DOUBLE_FP_ALIGNMENT;
-                    } else {
-                        /* HAVE_MAX_FP_ALIGNMENT may not be defined, hence commented */
-                        /*
-                         * if (tmp_alignsize > HAVE_MAX_FP_ALIGNMENT)
-                         * tmp_alignsize = HAVE_MAX_FP_ALIGNMENT;
-                         */
-                    }
-#elif defined(HAVE_MAX_FP_ALIGNMENT)
-                    if (tmp_alignsize > HAVE_MAX_FP_ALIGNMENT)
-                        tmp_alignsize = HAVE_MAX_FP_ALIGNMENT;
-#endif
-#ifdef HAVE_DOUBLE_POS_ALIGNMENT
-                    /* sort of a hack, but so is this rule */
-                    if (oldtype_array[i] == MPI_DOUBLE && displacement_array[i] != (MPI_Aint) 0) {
-                        tmp_alignsize = 4;
-                    }
-#endif
-                    break;
-                default:
-#ifdef HAVE_MAX_INTEGER_ALIGNMENT
-                    if (tmp_alignsize > HAVE_MAX_INTEGER_ALIGNMENT)
-                        tmp_alignsize = HAVE_MAX_INTEGER_ALIGNMENT;
-#endif
-                    break;
-#ifdef HAVE_LLINT_POS_ALIGNMENT
-                    if (oldtype_array[i] == MPI_LONG_LONG_INT &&
-                        displacement_array[i] != (MPI_Aint) 0) {
-                        tmp_alignsize = 4;
-                    }
-#endif
-            }
+            tmp_alignsize = MPIR_Datatype_builtintype_alignment(oldtype_array[i]);
         } else {
             MPIR_Datatype *dtp;
-
             MPIR_Datatype_get_ptr(oldtype_array[i], dtp);
             tmp_alignsize = dtp->alignsize;
-            if (derived_alignsize < tmp_alignsize)
-                derived_alignsize = tmp_alignsize;
         }
         if (max_alignsize < tmp_alignsize)
             max_alignsize = tmp_alignsize;
-
     }
 
     return max_alignsize;
@@ -303,7 +220,7 @@ static int type_struct(int count,
     new_dtp->true_ub = true_ub_disp;
     new_dtp->ub = ub_disp;
 
-    new_dtp->alignsize = MPII_Type_struct_alignsize(count, oldtype_array, displacement_array);
+    new_dtp->alignsize = struct_alignsize(count, oldtype_array);
 
     new_dtp->extent = new_dtp->ub - new_dtp->lb;
     /* account for padding */

--- a/src/mpi/datatype/typerep/dataloop/dataloop.c
+++ b/src/mpi/datatype/typerep/dataloop/dataloop.c
@@ -339,7 +339,6 @@ void MPII_Dataloop_alloc_and_copy(int kind,
                                   MPII_Dataloop * old_loop, MPII_Dataloop ** new_loop_p)
 {
     MPI_Aint new_loop_sz = 0;
-    int align_sz;
     int epsilon;
     MPI_Aint loop_sz = sizeof(MPII_Dataloop);
     MPI_Aint off_sz = 0, blk_sz = 0, ptr_sz = 0, extent_sz = 0;
@@ -348,14 +347,8 @@ void MPII_Dataloop_alloc_and_copy(int kind,
     MPII_Dataloop *new_loop;
     MPI_Aint old_loop_sz = old_loop ? old_loop->dloop_sz : 0;
 
-#ifdef HAVE_MAX_STRUCT_ALIGNMENT
-    align_sz = HAVE_MAX_STRUCT_ALIGNMENT;
-#else
-    align_sz = 8;       /* default aligns everything to 8-byte boundaries */
-#endif
-
     if (old_loop != NULL) {
-        MPIR_Assert((old_loop_sz % align_sz) == 0);
+        MPIR_Assert((old_loop_sz % MAX_ALIGNMENT) == 0);
     }
 
     /* calculate the space that we actually need for everything */
@@ -380,25 +373,25 @@ void MPII_Dataloop_alloc_and_copy(int kind,
     }
 
     /* pad everything that we're going to allocate */
-    epsilon = loop_sz % align_sz;
+    epsilon = loop_sz % MAX_ALIGNMENT;
     if (epsilon)
-        loop_sz += align_sz - epsilon;
+        loop_sz += MAX_ALIGNMENT - epsilon;
 
-    epsilon = off_sz % align_sz;
+    epsilon = off_sz % MAX_ALIGNMENT;
     if (epsilon)
-        off_sz += align_sz - epsilon;
+        off_sz += MAX_ALIGNMENT - epsilon;
 
-    epsilon = blk_sz % align_sz;
+    epsilon = blk_sz % MAX_ALIGNMENT;
     if (epsilon)
-        blk_sz += align_sz - epsilon;
+        blk_sz += MAX_ALIGNMENT - epsilon;
 
-    epsilon = ptr_sz % align_sz;
+    epsilon = ptr_sz % MAX_ALIGNMENT;
     if (epsilon)
-        ptr_sz += align_sz - epsilon;
+        ptr_sz += MAX_ALIGNMENT - epsilon;
 
-    epsilon = extent_sz % align_sz;
+    epsilon = extent_sz % MAX_ALIGNMENT;
     if (epsilon)
-        extent_sz += align_sz - epsilon;
+        extent_sz += MAX_ALIGNMENT - epsilon;
 
     new_loop_sz += loop_sz + off_sz + blk_sz + ptr_sz + extent_sz + old_loop_sz;
 

--- a/src/mpi/datatype/typerep/dataloop/looputil.c
+++ b/src/mpi/datatype/typerep/dataloop/looputil.c
@@ -775,7 +775,7 @@ void MPIR_Type_access_contents(MPI_Datatype type,
                                int **ints_p, MPI_Aint ** aints_p, MPI_Datatype ** types_p)
 {
     int nr_ints, nr_aints, nr_types, combiner;
-    int types_sz, struct_sz, ints_sz, epsilon, align_sz;
+    int types_sz, struct_sz, ints_sz, epsilon;
     MPIR_Datatype *dtp;
     MPIR_Datatype_contents *cp;
 
@@ -788,24 +788,18 @@ void MPIR_Type_access_contents(MPI_Datatype type,
     cp = dtp->contents;
     MPIR_Assert(cp != NULL);
 
-#ifdef HAVE_MAX_STRUCT_ALIGNMENT
-    align_sz = HAVE_MAX_STRUCT_ALIGNMENT;
-#else
-    align_sz = 8;
-#endif
-
     struct_sz = sizeof(MPIR_Datatype_contents);
     types_sz = nr_types * sizeof(MPI_Datatype);
     ints_sz = nr_ints * sizeof(int);
 
-    if ((epsilon = struct_sz % align_sz)) {
-        struct_sz += align_sz - epsilon;
+    if ((epsilon = struct_sz % MAX_ALIGNMENT)) {
+        struct_sz += MAX_ALIGNMENT - epsilon;
     }
-    if ((epsilon = types_sz % align_sz)) {
-        types_sz += align_sz - epsilon;
+    if ((epsilon = types_sz % MAX_ALIGNMENT)) {
+        types_sz += MAX_ALIGNMENT - epsilon;
     }
-    if ((epsilon = ints_sz % align_sz)) {
-        ints_sz += align_sz - epsilon;
+    if ((epsilon = ints_sz % MAX_ALIGNMENT)) {
+        ints_sz += MAX_ALIGNMENT - epsilon;
     }
     *types_p = (MPI_Datatype *) (((char *) cp) + struct_sz);
     *ints_p = (int *) (((char *) (*types_p)) + types_sz);


### PR DESCRIPTION
The alignment code in MPICH is incorrect in that it assumes that, for
basic types, the size and alignments match up.  This is fundamentally
incorrect.  On 32-bit platforms, for example, 64-bit types are
emulated, so their sizes might be 8 bytes, but their alignment
requires are still 4 bytes.  This also holds for larger types, such as
long double, where some platforms (e.g., Cygwin) define it as 12
bytes, but their alignment requirement is 16 bytes.  In short, size is
not a proxy for alignment and should not be used as such.

A side benefit of using native alignment checks is that the code is
much simpler than earlier.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
